### PR TITLE
security: v0.11.2 — WSL firewall scoping, debug dump permissions, MCP log redaction

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-09-08
+
+Security release. Recommended for anyone who set up WSL login, and for anyone
+who runs the MCP server with debug logging.
+
+### Security
+
+- **WSL CDP bridge is now scoped to the WSL virtual adapter.** The `netsh portproxy`
+  that bridges WSL to Windows Chrome listens on `0.0.0.0`, so the Windows Firewall
+  rule is the only boundary in front of Chrome DevTools Protocol, which has no
+  authentication. The rule printed by `nlm login --wsl` and built by
+  `create_firewall_rule()` now carries `-InterfaceAlias "vEthernet (WSL)"`, so traffic
+  arriving on Wi-Fi or Ethernet cannot match it. Interface scoping is what does the
+  work here: the WSL adapter usually lands on the **Public** network profile, so
+  profile filtering cannot separate it from a real network. `-RemoteAddress LocalSubnet`
+  is kept as a second layer. The privilege-failure fallback command previously printed
+  no `-RemoteAddress` at all, which defaults to `Any`; it is now scoped like the others.
+  Thanks to **@Naor-Peretz** for the report (GHSA-v558-4774-r6wq).
+
+  **Existing WSL users must act.** The firewall rule and the port proxy are created by
+  you, in Windows, so upgrading cannot change them. See
+  [Removing the bridge](./docs/WSL_SETUP.md#removing-the-bridge) to check whether your
+  rule is scoped and to replace it if not.
+
+- **`debug_page.html` is now created private.** The debug dump of the authenticated
+  page was written with the process umask and narrowed with `chmod` afterwards, leaving
+  a window in which it was world-readable, and the `chmod` failure was suppressed
+  silently. It is now created `0o600` atomically with `os.open`, matching the pattern
+  already used for credential writes in `core/auth.py` and `utils/cdp.py`.
+  Thanks to **@Naor-Peretz** for the report (GHSA-747w-q55c-m74m).
+
+- **MCP debug logging now redacts responses, not only requests.** Request parameters
+  were sanitized while responses were serialized whole, with a 1000-character
+  truncation as the only limit. Redaction is now recursive, covers nested dicts and
+  lists in both requests and responses, and matches sensitive key names by substring
+  (`token`, `secret`, `password`, `credential`, `apikey`, `authorization`, `bearer`
+  and others) rather than an exact five-key denylist that failed open for anything
+  added later. Thanks to **@Naor-Peretz** for the report (GHSA-jhrc-qgxv-3c2g).
+
+### Added
+
+- `SECURITY.md` with a private reporting channel, response targets, and scope.
+- `.github/dependabot.yml` for weekly Python and GitHub Actions updates.
+- Regression tests: `tests/test_log_redaction.py`, `tests/test_debug_page_permissions.py`,
+  `tests/test_wsl_firewall_scope.py`.
+
+### Changed
+
+- `docs/WSL_SETUP.md` now documents the teardown commands for the firewall rule and the
+  port proxy, states the exposure honestly instead of claiming external hosts cannot
+  reach the port, and explains how to replace a pre-0.11.2 rule.
+- The `utils/wsl.py` module docstring described the pre-0.5.24 architecture, in which
+  Chrome bound `--remote-debugging-address=0.0.0.0`, and referenced
+  `docs/SECURITY_REMEDIATION_PLAN.md`, which is not in the repository. Rewritten to
+  describe the port proxy and its actual limits.
+
 ## [0.11.1] - 2026-09-07
 
 Security release. Upgrading is recommended for anyone running the MCP server.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately through GitHub's advisory form:
+
+**https://github.com/jacob-bd/gemini-notebook-mcp-cli/security/advisories/new**
+
+Please do not open a public issue for anything that looks exploitable. If you
+are not sure whether something qualifies, report it privately and we will sort
+it out together.
+
+Helpful things to include, though none of them are required:
+
+1. The version or commit you reviewed
+2. The affected file and line
+3. What an attacker gains, stated as narrowly as you can
+4. A proof of concept, if you have one
+5. A suggested fix, if you have one
+
+## What to expect
+
+| Stage | Target |
+|---|---|
+| First response | 3 business days |
+| Triage and severity decision | 7 business days |
+| Fix released for High or Critical | 14 days from triage |
+| Fix released for Low or Medium | Next scheduled release |
+
+This is a personal open source project, not a funded product, so these are
+targets rather than guarantees. If a report goes quiet, please ping the
+advisory thread.
+
+## Supported versions
+
+Only the latest released version gets security fixes. Please upgrade before
+reporting an issue against an older release.
+
+| Version | Supported |
+|---|---|
+| 0.11.x | Yes |
+| < 0.11 | No |
+
+## Scope
+
+In scope:
+
+- The `notebooklm-mcp` MCP server and its tools
+- The `nlm` CLI
+- Credential handling, file writes, and the authentication flows
+- Setup instructions in `docs/` that create a security boundary
+
+Out of scope:
+
+- Vulnerabilities in Google's services. Please report those to Google.
+- Chrome DevTools Protocol having no authentication. That is Chrome's design.
+- Anything that requires an attacker to already have your Google session
+  cookies.
+
+## Credit
+
+Reporters get credited in `CHANGELOG.md` and in the published advisory unless
+they ask not to be. Please say so in the report if you would rather stay
+anonymous.
+
+## No bounty
+
+There is no bug bounty program and no payment. Reports are welcome anyway, and
+they get taken seriously.

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "gemini-notebook-mcp",
   "display_name": "Gemini Notebook MCP Server",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Connect Claude to Gemini Notebook. Create podcasts, research topics, generate quizzes, flashcards, mind maps, and more from your notebooks.",
   "long_description": "This extension connects Claude Desktop to Gemini Notebook via the Model Context Protocol. It provides 43 tools for managing notebooks, sources, labels, chat sessions, research, sharing, and generated content.\n\n**Prerequisites:**\n1. Install the package: `pip install notebooklm-mcp-cli` or `uv tool install notebooklm-mcp-cli`\n2. Authenticate: Run `nlm login` to set up your Google account\n\n**Features:**\n- Create and manage notebooks\n- Add sources (URLs, YouTube, Google Drive, text, files)\n- Generate podcasts (Audio Overview)\n- Create quizzes, flashcards, mind maps, reports\n- Research topics with web or Drive search",
   "author": {

--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -36,17 +36,32 @@ via port **9222** (the proxy port accessible from WSL).
 netsh interface portproxy add v4tov4 listenport=9222 listenaddress=0.0.0.0 connectport=9223 connectaddress=127.0.0.1
 ```
 
+The port proxy listens on `0.0.0.0`, so the Windows Firewall rule is the only
+boundary in front of it. Chrome DevTools Protocol has no authentication, so
+anything that reaches port 9222 while Chrome is running can drive the browser.
+
 **Mitigations in place:**
-- **Windows Firewall**: Only connections from `LocalSubnet` (WSL virtual network)
-  are allowed to reach port 9222
+- **Windows Firewall**: The rule is scoped with `-InterfaceAlias "vEthernet (WSL)"`,
+  so traffic arriving on Wi-Fi or Ethernet cannot match it. `-RemoteAddress LocalSubnet`
+  is kept as a second layer. Interface scoping is what does the work here, because the
+  WSL adapter usually lands on the **Public** network profile and profile filtering
+  cannot separate it from a real network.
 - **Port proxy**: Only forwards to localhost:9223; Chrome is never exposed
   directly on the network
 - **Temporary profiles**: Each Chrome instance uses a fresh, isolated profile
   on the Windows filesystem that is cleaned up after authentication
 - **Short-lived**: Remote debugging is only active during the explicit `nlm login --wsl`
-  command and terminated immediately after
-- **No external exposure**: The Windows Firewall rule prevents connections from
-  external network hosts
+  command and terminated immediately after. Outside that window nothing listens on 9223,
+  so the bridge forwards to a closed port.
+
+**Known limits, stated plainly:**
+- You create the port proxy and the firewall rule yourself, in Windows. Nothing in this
+  package can remove them, and both survive upgrades. See
+  [Removing the bridge](#removing-the-bridge) below.
+- If you created the firewall rule before v0.11.2 it has no `-InterfaceAlias` and applies
+  to every adapter on every network profile. Replace it using the commands below.
+- If you later switch WSL to mirrored networking, the rule is no longer needed at all and
+  should be removed.
 
 If you have concerns about this setup, you can use manual mode instead:
 ```bash
@@ -122,6 +137,32 @@ WSL Auth Script
     ↓  waits for login
     ↓  extracts cookies via CDP
     ↓  terminates Chrome process
+```
+
+## Removing the bridge
+
+The port proxy and the firewall rule persist until you remove them. Run both in an
+**elevated PowerShell** when you no longer need WSL login, or before recreating a
+narrower rule:
+
+```powershell
+Remove-NetFirewallRule -DisplayName "NotebookLM-CDP-9222"
+netsh interface portproxy delete v4tov4 listenport=9222 listenaddress=0.0.0.0
+```
+
+### Replacing a pre-v0.11.2 firewall rule
+
+Check whether your existing rule is scoped to the WSL adapter:
+
+```powershell
+Get-NetFirewallRule -DisplayName "NotebookLM-CDP-9222" | Get-NetFirewallInterfaceFilter
+```
+
+If `InterfaceAlias` comes back as `Any`, remove the rule and create the scoped one:
+
+```powershell
+Remove-NetFirewallRule -DisplayName "NotebookLM-CDP-9222"
+New-NetFirewallRule -DisplayName "NotebookLM-CDP-9222" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 9222 -InterfaceAlias "vEthernet (WSL)" -RemoteAddress LocalSubnet
 ```
 
 ## Troubleshooting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "notebooklm-mcp-cli"
-version = "0.11.1"
+version = "0.11.2"
 description = "Unified CLI and MCP server for Google NotebookLM"
 readme = "README.md"
 license = "MIT"

--- a/src/notebooklm_tools/__init__.py
+++ b/src/notebooklm_tools/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import notebooklm_tools.utils.env_sanitize as _env_sanitize  # noqa: F401
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 __all__ = ["NotebookLMClient", "__version__"]
 

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -365,7 +365,7 @@ def login_callback(
                 wsl = False
 
         if wsl:
-            from notebooklm_tools.utils.wsl import DEFAULT_WSL_CDP_PORT
+            from notebooklm_tools.utils.wsl import DEFAULT_WSL_CDP_PORT, WSL_ADAPTER_ALIAS
 
             wsl_port = DEFAULT_WSL_CDP_PORT
             # Chrome binds to localhost only (newer Chrome ignores
@@ -405,7 +405,7 @@ def login_callback(
                     "\n[bold]Step 1:[/bold] Open [cyan]Windows PowerShell as Administrator[/cyan] and run:"
                 )
                 console.print(
-                    f'\n  New-NetFirewallRule -DisplayName "NotebookLM-CDP-{wsl_port}" -Direction Inbound -Action Allow -Protocol TCP -LocalPort {wsl_port} -RemoteAddress LocalSubnet\n'
+                    f'\n  New-NetFirewallRule -DisplayName "NotebookLM-CDP-{wsl_port}" -Direction Inbound -Action Allow -Protocol TCP -LocalPort {wsl_port} -InterfaceAlias "{WSL_ADAPTER_ALIAS}" -RemoteAddress LocalSubnet\n'
                 )
                 console.print(
                     "[bold]Step 2:[/bold] After running the command above, press [bold]Enter[/bold] here to continue..."
@@ -423,6 +423,12 @@ def login_callback(
                 console.print()
             else:
                 console.print("[dim]Windows Firewall: rule exists[/dim]")
+                console.print(
+                    f'[dim]If you created it before v0.11.2 it may not be scoped to "{WSL_ADAPTER_ALIAS}".[/dim]'
+                )
+                console.print(
+                    "[dim]See docs/WSL_SETUP.md (Removing the bridge) to check and replace it.[/dim]"
+                )
             console.print()
 
             try:

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -1251,11 +1251,18 @@ class BaseClient:
 
                 debug_dir = get_storage_dir()
                 debug_path = debug_dir / "debug_page.html"
-                debug_path.write_text(html, encoding="utf-8")
-                import contextlib as _ctxlib
-
-                with _ctxlib.suppress(OSError):
-                    debug_path.chmod(0o600)
+                # The dump is the authenticated page: session identifiers and
+                # notebook metadata. Create it 0o600 atomically rather than
+                # writing first and narrowing after, which leaves a window in
+                # which the file is world-readable.
+                fd = os.open(str(debug_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                try:
+                    f = os.fdopen(fd, "w", encoding="utf-8")
+                except BaseException:
+                    os.close(fd)
+                    raise
+                with f:
+                    f.write(html)
                 raise ValueError(
                     f"Could not extract CSRF token from page. "
                     f"Page saved to {debug_path} for debugging. "

--- a/src/notebooklm_tools/data/AGENTS_SECTION.md
+++ b/src/notebooklm_tools/data/AGENTS_SECTION.md
@@ -1,5 +1,5 @@
 <!-- nlm-skill-start -->
-<!-- nlm-version: 0.11.1 -->
+<!-- nlm-version: 0.11.2 -->
 ## NLM - Gemini Notebook (formerly Google NotebookLM) CLI Expert
 
 **Triggers:** "nlm", "notebooklm", "Gemini Notebook", "podcast", "audio overview", "research"

--- a/src/notebooklm_tools/data/SKILL.md
+++ b/src/notebooklm_tools/data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nlm-skill
-version: "0.11.1"
+version: "0.11.2"
 description: 'Expert guide for the Gemini Notebook (formerly Google NotebookLM) CLI (`nlm`) and MCP server - interfaces for Gemini Notebook. Use this skill when users want to interact with Gemini Notebook programmatically, including: creating/managing notebooks, adding sources (URLs, YouTube, text, Google Drive), generating content (podcasts, reports, quizzes, flashcards, mind maps, slides, infographics, videos, data tables), conducting research, chatting with sources, or automating Gemini Notebook workflows. Triggers on mentions of "nlm", "notebooklm", "Gemini Notebook", "podcast generation", "audio overview", "refactor document", "critique draft", or any Gemini Notebook-related automation task.'
 ---
 

--- a/src/notebooklm_tools/mcp/tools/_utils.py
+++ b/src/notebooklm_tools/mcp/tools/_utils.py
@@ -17,10 +17,35 @@ from notebooklm_tools.services.errors import ServiceError
 # MCP request/response logger
 mcp_logger = logging.getLogger("notebooklm_tools.mcp")
 
-# Parameters that must never appear in log output
+# Keys that must never appear in log output, matched exactly.
 _SENSITIVE_PARAMS = frozenset(
     {"cookies", "csrf_token", "session_id", "request_body", "request_url"}
 )
+
+# Substrings that mark a key as sensitive wherever it appears, including in
+# nested response payloads. An exact denylist is fail-open: any key added to a
+# tool signature or a service return value later would log in clear by default.
+# These markers make the common shapes fail closed instead.
+_SENSITIVE_MARKERS = (
+    "cookie",
+    "csrf",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "apikey",
+    "api_key",
+    "authorization",
+    "bearer",
+    "session_id",
+    "sessionid",
+    "request_body",
+    "request_url",
+)
+
+# Guard against deeply nested or self-referential payloads.
+_MAX_REDACT_DEPTH = 8
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")
@@ -29,9 +54,37 @@ _StrConverter: TypeAlias = Callable[[Any], str]
 _DEFAULT_STR_CONVERTER: _StrConverter = str
 
 
+def _is_sensitive_key(key: str) -> bool:
+    """True if a key name should have its value redacted before logging."""
+    if key in _SENSITIVE_PARAMS:
+        return True
+    normalized = key.lower()
+    return any(marker in normalized for marker in _SENSITIVE_MARKERS)
+
+
+def _redact(value: Any, _depth: int = 0) -> Any:
+    """Recursively replace sensitive values with [REDACTED] before logging.
+
+    Walks dicts and lists so nested payloads are covered, not just top-level
+    keyword arguments.
+    """
+    if _depth >= _MAX_REDACT_DEPTH:
+        return "[TRUNCATED]"
+    if isinstance(value, dict):
+        return {
+            k: "[REDACTED]"
+            if isinstance(k, str) and _is_sensitive_key(k)
+            else _redact(v, _depth + 1)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact(item, _depth + 1) for item in value]
+    return value
+
+
 def _sanitize_params(params: ResultDict) -> ResultDict:
     """Replace sensitive parameter values with [REDACTED] before logging."""
-    return {k: "[REDACTED]" if k in _SENSITIVE_PARAMS else v for k, v in params.items()}
+    return cast(ResultDict, _redact(params))
 
 
 def error_result(
@@ -193,7 +246,7 @@ def logged_tool() -> Callable[[Callable[P, Any]], Callable[P, Any]]:
                 result: Any = await async_func(*args, **kwargs)
 
                 if mcp_logger.isEnabledFor(logging.DEBUG):
-                    result_str = json.dumps(result, default=str)
+                    result_str = json.dumps(_redact(result), default=str)
                     if len(result_str) > 1000:
                         result_str = result_str[:1000] + "..."
                     mcp_logger.debug(f"MCP Response: {tool_name} -> {result_str}")
@@ -214,7 +267,7 @@ def logged_tool() -> Callable[[Callable[P, Any]], Callable[P, Any]]:
                 result: R = sync_func(*args, **kwargs)
 
                 if mcp_logger.isEnabledFor(logging.DEBUG):
-                    result_str = json.dumps(result, default=str)
+                    result_str = json.dumps(_redact(result), default=str)
                     if len(result_str) > 1000:
                         result_str = result_str[:1000] + "..."
                     mcp_logger.debug(f"MCP Response: {tool_name} -> {result_str}")

--- a/src/notebooklm_tools/utils/wsl.py
+++ b/src/notebooklm_tools/utils/wsl.py
@@ -6,18 +6,25 @@ the cross-boundary authentication flow.
 
 Security Note:
 --------------
-This module launches Chrome with --remote-debugging-address=0.0.0.0 to allow
-connections from the WSL2 virtual network. This differs from the standard
-H-3 remediation (which restricts to 127.0.0.1) because WSL2 uses a virtual
-network bridge that requires cross-boundary access.
+Chrome is launched with --remote-debugging-port only, so it binds to
+127.0.0.1 on the Windows side. Chrome 136+ ignores
+--remote-debugging-address, so WSL reaches it through a `netsh portproxy`
+bridge that the user creates manually (see docs/WSL_SETUP.md).
 
-Mitigations in place:
-- Windows Firewall limits connections to LocalSubnet (WSL virtual network only)
-- Temporary Chrome profiles are used and cleaned up after authentication
-- Chrome remote debugging is only active during explicit nlm login --wsl
-- No other network hosts can reach the debugging port
+That bridge listens on 0.0.0.0, so the Windows Firewall rule is the only
+boundary in front of it. The rule is therefore scoped to the WSL virtual
+adapter with -InterfaceAlias, so traffic arriving on Wi-Fi or Ethernet
+cannot match it regardless of network profile. -RemoteAddress LocalSubnet
+is kept as a second layer, not as the primary control.
 
-See: docs/SECURITY_REMEDIATION_PLAN.md (H-3) for original security context.
+Known limits:
+- The portproxy and the firewall rule are created by the user, in Windows.
+  Nothing in this package can remove them. docs/WSL_SETUP.md documents the
+  teardown commands.
+- Chrome only listens during an explicit `nlm login --wsl`, so the CDP
+  endpoint is unreachable outside that window. The bridge itself persists.
+- Users who created the rule before v0.11.2 have an adapter-wide rule and
+  must replace it using the commands in docs/WSL_SETUP.md.
 """
 
 import contextlib
@@ -33,6 +40,13 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_WSL_CDP_PORT = 9222
+
+# The firewall rule for the CDP bridge is scoped to the WSL virtual adapter.
+# The adapter routinely lands on the Public network profile, so profile-based
+# filtering cannot separate it from real networks; interface scoping can.
+# The alias is stable across reboots even though the WSL IP is not.
+WSL_ADAPTER_ALIAS = "vEthernet (WSL)"
+
 WINDOWS_CHROME_PATHS = [
     r"C:\Program Files\Google\Chrome\Application\chrome.exe",
     r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
@@ -507,6 +521,7 @@ def create_firewall_rule(port: int = DEFAULT_WSL_CDP_PORT) -> tuple[bool, str]:
         ps_cmd = (
             f"New-NetFirewallRule -DisplayName '{rule_name}' "
             f"-Direction Inbound -Action Allow -Protocol TCP -LocalPort {port} "
+            f"-InterfaceAlias '{WSL_ADAPTER_ALIAS}' "
             f"-RemoteAddress LocalSubnet "
             f"-Description 'Allow WSL2 to connect to Chrome DevTools Protocol for NotebookLM MCP'"
         )
@@ -537,7 +552,9 @@ def create_firewall_rule(port: int = DEFAULT_WSL_CDP_PORT) -> tuple[bool, str]:
                     "Administrator privileges required.\n"
                     "Please run in Windows PowerShell (as Administrator):\n"
                     f"  New-NetFirewallRule -DisplayName '{rule_name}' "
-                    f"-Direction Inbound -Action Allow -Protocol TCP -LocalPort {port}"
+                    f"-Direction Inbound -Action Allow -Protocol TCP -LocalPort {port} "
+                    f"-InterfaceAlias '{WSL_ADAPTER_ALIAS}' "
+                    f"-RemoteAddress LocalSubnet"
                 )
             return False, error
 

--- a/tests/test_debug_page_permissions.py
+++ b/tests/test_debug_page_permissions.py
@@ -1,0 +1,73 @@
+"""Regression test for the debug_page.html dump permissions.
+
+Covers GHSA-747w-q55c-m74m: the dump was written with the process umask and
+chmod'd afterwards, leaving a window in which the authenticated page was
+world-readable. It must be created 0o600 atomically instead.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from notebooklm_tools.core import base
+
+
+class _FakeResponse:
+    url = "https://notebook.google.com/"
+    status_code = 200
+    text = "<html>no csrf token anywhere in here</html>"
+
+
+class _FakeClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, *args, **kwargs):
+        return _FakeResponse()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes only")
+def test_debug_dump_is_created_private(tmp_path, monkeypatch):
+    monkeypatch.setattr(httpx, "Client", _FakeClient)
+    monkeypatch.setattr(base.BaseClient, "_get_httpx_cookies", lambda self: {})
+    monkeypatch.setattr(
+        "notebooklm_tools.core.cookie_rotation.rotate_google_cookies", lambda c: None
+    )
+    monkeypatch.setattr("notebooklm_tools.utils.config.get_storage_dir", lambda: tmp_path)
+
+    client = base.BaseClient.__new__(base.BaseClient)
+    monkeypatch.setattr(type(client), "_get_base_url", lambda self: "https://notebook.google.com")
+    monkeypatch.setattr(type(client), "_is_enterprise", lambda self: False)
+
+    # The file must be private at creation, not narrowed afterwards. A
+    # post-hoc chmod leaves a window, and this codebase suppressed its
+    # OSError, so a failed chmod left the dump world-readable forever.
+    # Patching chmod to fail proves the mode does not depend on it.
+    def _refuse_chmod(self, mode):
+        raise OSError("chmod refused")
+
+    monkeypatch.setattr(Path, "chmod", _refuse_chmod)
+
+    # A loose umask must not widen the file either.
+    old_umask = os.umask(0o000)
+    try:
+        with pytest.raises(ValueError, match="Could not extract CSRF token"):
+            client._refresh_auth_tokens()
+    finally:
+        os.umask(old_umask)
+
+    debug_file = tmp_path / "debug_page.html"
+    assert debug_file.exists(), "debug dump should have been written"
+    mode = stat.S_IMODE(debug_file.stat().st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    assert debug_file.read_text() == _FakeResponse.text

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,92 @@
+"""Regression tests for MCP debug log redaction.
+
+Covers GHSA-jhrc-qgxv-3c2g: requests were sanitized but responses were
+serialized whole, and the denylist was exact-match only.
+"""
+
+import json
+
+import pytest
+
+from notebooklm_tools.mcp.tools._utils import (
+    _is_sensitive_key,
+    _redact,
+    _sanitize_params,
+)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "cookies",
+        "csrf_token",
+        "session_id",
+        "request_body",
+        "request_url",
+        "access_token",
+        "refresh_token",
+        "api_key",
+        "apiKey",
+        "Authorization",
+        "client_secret",
+        "password",
+        "bearer_token",
+        "user_credentials",
+    ],
+)
+def test_sensitive_keys_detected(key):
+    assert _is_sensitive_key(key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["query", "title", "notebook_id", "author", "download_url", "artifact_type", "count"],
+)
+def test_ordinary_keys_survive(key):
+    assert not _is_sensitive_key(key)
+
+
+def test_top_level_request_params_redacted():
+    out = _sanitize_params({"cookies": "SID=abc", "query": "hello"})
+    assert out == {"cookies": "[REDACTED]", "query": "hello"}
+
+
+def test_nested_response_redacted():
+    payload = {
+        "success": True,
+        "auth": {"cookies": "SID=abc", "csrf_token": "at123"},
+        "sources": [{"name": "a"}, {"name": "b", "access_token": "leaky"}],
+    }
+    out = _redact(payload)
+    assert out["auth"]["cookies"] == "[REDACTED]"
+    assert out["auth"]["csrf_token"] == "[REDACTED]"
+    assert out["sources"][1]["access_token"] == "[REDACTED]"
+    assert out["sources"][0]["name"] == "a"
+    assert out["success"] is True
+
+
+def test_no_secret_survives_serialization():
+    payload = {"level1": {"level2": {"session_id": "s3cret-value"}}}
+    assert "s3cret-value" not in json.dumps(_redact(payload), default=str)
+
+
+def test_deep_nesting_is_bounded():
+    node: dict = {}
+    cursor = node
+    for _ in range(30):
+        cursor["next"] = {}
+        cursor = cursor["next"]
+    assert "[TRUNCATED]" in json.dumps(_redact(node), default=str)
+
+
+def test_original_payload_not_mutated():
+    payload = {"cookies": "SID=abc"}
+    _redact(payload)
+    assert payload["cookies"] == "SID=abc"
+
+
+def test_non_dict_values_pass_through():
+    assert _redact("plain") == "plain"
+    assert _redact(42) == 42
+    assert _redact(None) is None
+    assert _redact([1, 2, 3]) == [1, 2, 3]

--- a/tests/test_wsl_firewall_scope.py
+++ b/tests/test_wsl_firewall_scope.py
@@ -1,0 +1,67 @@
+"""Regression tests for WSL firewall rule scoping.
+
+Covers GHSA-v558-4774-r6wq: the CDP bridge listens on 0.0.0.0, so the Windows
+Firewall rule is the only boundary in front of an unauthenticated protocol. It
+must be scoped to the WSL virtual adapter, because that adapter usually lands
+on the Public network profile and profile filtering cannot separate it from a
+real network. The privilege-failure fallback previously printed a command with
+no -RemoteAddress at all, which defaults to Any.
+"""
+
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from notebooklm_tools.utils import wsl
+
+
+def _run_result(returncode: int, stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], returncode=returncode, stdout="", stderr=stderr)
+
+
+@pytest.fixture
+def _wsl_env(monkeypatch):
+    monkeypatch.setattr(wsl, "is_wsl", lambda: True)
+    monkeypatch.setattr(wsl, "_get_powershell_path", lambda: "/mnt/c/powershell.exe")
+
+
+def test_created_rule_is_scoped_to_the_wsl_adapter(_wsl_env, monkeypatch):
+    run = Mock(return_value=_run_result(0))
+    monkeypatch.setattr(wsl.subprocess, "run", run)
+
+    ok, _ = wsl.create_firewall_rule(9222)
+    assert ok
+
+    ps_cmd = run.call_args.args[0][-1]
+    assert f"-InterfaceAlias '{wsl.WSL_ADAPTER_ALIAS}'" in ps_cmd
+    assert "-RemoteAddress LocalSubnet" in ps_cmd
+
+
+def test_privilege_fallback_command_is_not_wide_open(_wsl_env, monkeypatch):
+    monkeypatch.setattr(
+        wsl.subprocess, "run", Mock(return_value=_run_result(1, "Access is denied"))
+    )
+
+    ok, message = wsl.create_firewall_rule(9222)
+    assert not ok
+    assert "New-NetFirewallRule" in message, "fallback should print a command"
+    assert f"-InterfaceAlias '{wsl.WSL_ADAPTER_ALIAS}'" in message
+    assert "-RemoteAddress LocalSubnet" in message
+
+
+def test_cli_prompt_prints_a_scoped_rule():
+    """The command users actually copy must carry the same scoping."""
+    from pathlib import Path
+
+    source = Path(wsl.__file__).parent.parent / "cli" / "main.py"
+    text = source.read_text(encoding="utf-8")
+    line = next(ln for ln in text.splitlines() if "New-NetFirewallRule -DisplayName" in ln)
+    assert "-InterfaceAlias" in line
+    assert "-RemoteAddress LocalSubnet" in line
+
+
+def test_docstring_makes_no_unqualified_isolation_claim():
+    """The old docstring promised no other host could reach the port."""
+    assert "No other network hosts can reach" not in (wsl.__doc__ or "")
+    assert "SECURITY_REMEDIATION_PLAN" not in (wsl.__doc__ or "")

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-mcp-cli"
-version = "0.10.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Fixes three privately reported advisories from **@Naor-Peretz**. Release v0.11.2.

| Advisory | Severity | Fix |
|---|---|---|
| GHSA-v558-4774-r6wq | Medium (was reported High) | WSL firewall rule scoped to the WSL adapter |
| GHSA-747w-q55c-m74m | Low | `debug_page.html` created `0o600` atomically |
| GHSA-jhrc-qgxv-3c2g | Low | MCP debug logging redacts responses, matches keys by pattern |

## GHSA-v558 — WSL CDP bridge

The `netsh portproxy` bridging WSL to Windows Chrome listens on `0.0.0.0`, so the Windows Firewall rule is the only boundary in front of Chrome DevTools Protocol, which has no authentication. The rule set no `-Profile` and no interface scope, and the WSL adapter usually lands on the **Public** profile, so profile filtering cannot separate it from a real network.

- `-InterfaceAlias "vEthernet (WSL)"` added to the rule printed by `nlm login --wsl`, to `create_firewall_rule()`, and to the privilege-failure fallback. That fallback printed no `-RemoteAddress` at all, which defaults to `Any`.
- Teardown documented for both the rule and the proxy, plus how to detect and replace a pre-0.11.2 rule. Neither is created by this package, so upgrading alone cannot fix an existing install.
- The existing-rule path in `nlm login --wsl` was silent; it now points at the teardown docs.
- `utils/wsl.py` docstring rewritten. It described the pre-0.5.24 architecture, claimed no other network host could reach the debug port, and referenced a file not in the repo.

**Severity:** reported at 8.1 High. The reported `AC:L` pairs the permanence of the leftover rule with the impact of CDP session theft, but those are separate: nothing listens on 9223 outside an active `nlm login --wsl`, and Chrome is terminated when it ends. Re-scored `AV:A/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N` = **6.4 Medium**.

`listenaddress` stays `0.0.0.0`. Pinning it to the host WSL IP would break login on every reboot, since that address is reassigned.

## GHSA-747w — debug dump permissions

Written with the process umask then narrowed with `chmod`, leaving a world-readable window, with the `chmod` failure suppressed silently. Now created `0o600` atomically via `os.open`, matching `core/auth.py` and `utils/cdp.py`.

## GHSA-jhrc — MCP log redaction

Requests were sanitized; responses were serialized whole. The five-key denylist was fail-open and had already needed manual extension once inside an unrelated feature commit.

- Recursive redaction across nested dicts and lists, on requests and responses, with a depth cap.
- Sensitive key names matched by substring so new fields fail closed.
- `author` and `download_url` deliberately survive, to keep logs debuggable.
- Adds `SECURITY.md` and `.github/dependabot.yml`.

## Testing

1580 passed, 39 skipped. Ruff clean. Version aligned across all 5 files, CHANGELOG written.

The `debug_page` test patches `chmod` to fail, because asserting the final mode passes against the old code too — the defect is the window, not the end state. Verified failing on old code (`0o666`) and passing on new.

https://claude.ai/code/session_014Roj5YtCnkkWJLPqRYe8z3