### PR TITLE
chore(security): keep authenticated debug captures out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,13 @@ run_log.txt
 # Credentials
 cookies.txt
 
+# Sensitive browser/debug artifacts
+dom_with_cookies.html
+dom_with_cookies-*.html
+*.har
+.chrome-debug-profile/
+.chrome-profile/
+
 # uv
 .uv/
 

--- a/scripts/inject_cookies_and_inspect.py
+++ b/scripts/inject_cookies_and_inspect.py
@@ -2,7 +2,9 @@
 Script to launch Chrome, inject saved cookies, and inspect DOM.
 """
 
+import argparse
 import json
+import tempfile
 import time
 from pathlib import Path
 
@@ -35,7 +37,19 @@ def inject_cookies(ws_url, cookies):
     print(f"Injected {len(cookies)} cookies.")
 
 
-def inspect_dom():
+def save_dom_capture(html: str, output_path: Path | None = None) -> Path:
+    """Save an authenticated DOM capture outside the repository by default."""
+    if output_path is None:
+        output_path = Path(tempfile.mkdtemp(prefix="notebooklm-dom-")) / "dom.html"
+    else:
+        output_path = Path(output_path).expanduser()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html, encoding="utf-8")
+    return output_path
+
+
+def inspect_dom(output_path: Path | None = None):
     tokens = load_cached_tokens()
     if not tokens:
         print("No tokens found in auth.json. Cannot inject.")
@@ -94,8 +108,8 @@ def inspect_dom():
     # 4. Dump HTML
     print("Capturing HTML...")
     html = get_page_html(ws_url)
-    Path("dom_with_cookies.html").write_text(html)
-    print("Saved to dom_with_cookies.html")
+    saved_path = save_dom_capture(html, output_path)
+    print(f"Saved authenticated DOM capture to {saved_path}")
 
     # 5. Click "Add Source" and Look for File Input
     print("\nClicking 'Add source' and searching for file inputs...")
@@ -183,4 +197,10 @@ def inspect_dom():
 
 
 if __name__ == "__main__":
-    inspect_dom()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Explicit path for the authenticated DOM capture; otherwise use a system temp directory.",
+    )
+    inspect_dom(parser.parse_args().output)

--- a/tests/test_debug_artifacts.py
+++ b/tests/test_debug_artifacts.py
@@ -1,0 +1,48 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "inject_cookies_and_inspect.py"
+_SPEC = importlib.util.spec_from_file_location("inject_cookies_and_inspect", _SCRIPT_PATH)
+assert _SPEC and _SPEC.loader
+_SCRIPT = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCRIPT)
+save_dom_capture = _SCRIPT.save_dom_capture
+
+
+def test_save_dom_capture_defaults_outside_the_repository(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    output = save_dom_capture("<html>private</html>")
+
+    assert output.is_file()
+    assert output.parent != tmp_path
+    assert output.name == "dom.html"
+    assert output.read_text(encoding="utf-8") == "<html>private</html>"
+
+
+def test_save_dom_capture_honors_explicit_output_path(tmp_path):
+    output_path = tmp_path / "captures" / "dom.html"
+
+    output = save_dom_capture("<html>private</html>", output_path)
+
+    assert output == output_path
+    assert output.read_text(encoding="utf-8") == "<html>private</html>"
+
+
+def test_sensitive_debug_artifacts_are_ignored_by_git():
+    repo_root = Path(__file__).parents[1]
+    for artifact in (
+        "dom_with_cookies.html",
+        "dom_with_cookies-2026-08-23.html",
+        "capture.har",
+        ".chrome-debug-profile/Cookies",
+    ):
+        result = subprocess.run(
+            ["git", "check-ignore", "--no-index", "--", artifact],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"{artifact} is not ignored"


### PR DESCRIPTION
No release needed. Developer script and repo hygiene only, no user-facing change.

## Problem

`scripts/inject_cookies_and_inspect.py` wrote its authenticated DOM capture to `dom_with_cookies.html` in the working directory. That file contains a live Google session, and sitting in the repo root it is one `git add .` away from being published.

Nothing ignored it, and nothing ignored the other artifacts this workflow produces either. HAR exports in particular carry full cookie headers.

## Change

- Captures go to a system temp directory by default. `--output` sets an explicit path.
- `.gitignore` covers DOM captures, `*.har`, and the Chrome debug profiles.
- Tests for both the default location and the ignore rules.

## Testing

1580 passed, 39 skipped. Ruff clean.

The ignore test is load-bearing, not decorative: reverting the `.gitignore` change fails it with `dom_with_cookies.html is not ignored`.

Same class as GHSA-747w-q55c-m74m, applied to a developer script rather than the client.

https://claude.ai/code/session_014Roj5YtCnkkWJLPqRYe8z3