### PR TITLE
feat: report remaining plan usage via `nlm usage` and `usage_get`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ also requires the target tool to be detected.
 | `note_list` | List all notes in a notebook |
 | `note_update` | Update a note's content or title |
 | `note_delete` | Delete a note (REQUIRES confirmation) |
+| `usage_get` | Show remaining plan usage per window (rolling + weekly) and reset times |
 
 **IMPORTANT - Operations Requiring Confirmation:**
 - `notebook_delete` requires `confirm=True` - deletion is IRREVERSIBLE
@@ -231,8 +232,13 @@ None - all Gemini Notebook features that can be accessed programmatically are im
 - Verify you're logged into the correct account
 
 ### Rate limit errors
-- Free tier: ~50 queries/day
-- Wait until the next day or upgrade to Plus
+- Since 2026-09-02, chat and Studio usage is metered as compute against two
+  windows at once: a short rolling window (~5h) and a weekly cap. Allowance
+  scales with plan tier.
+- Run `nlm usage` (MCP: `usage_get`) to see what is left in each window and
+  when it resets, instead of guessing.
+- Brief throttling is retried automatically with backoff; an exhausted window
+  needs to wait for the reset time that `nlm usage` reports.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Then use natural language: _"Create a notebook about quantum computing and gener
 | Configure AI tools                            | `nlm setup add/remove/list`     | —                                    |
 | Install AI Skills                             | `nlm skill install/update`      | —                                    |
 | Diagnose issues                               | `nlm doctor`                    | —                                    |
+| Check remaining plan usage                    | `nlm usage`                     | `usage_get`                          |
 
 📚 **More Documentation:**
 
@@ -659,7 +660,7 @@ uv tool list | grep notebooklm
 
 ## Limitations
 
-- **Rate limits**: Free tier has ~50 queries/day
+- **Rate limits**: Chat and Studio usage is metered as compute against a rolling (~5h) window and a weekly cap, scaled by plan tier. Run `nlm usage` to see what is left and when it resets
 - **No official support**: API may change without notice
 - **Cookie expiration**: Need to re-extract cookies every few weeks
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1905,6 +1905,59 @@ Also fires on every page load. Returns app settings including what appear to be 
 | Slide Decks | Limited | More | Higher | Highest |
 
 **Notes:**
-- Daily quotas reset after 24 hours; monthly quotas reset after 30 days
 - Auto-generated artifacts (on first source add) do NOT count toward limits
-- There is no API endpoint to query current usage counts — limits are enforced server-side
+- **Superseded for chat and Studio as of 2026-09-02** — see the compute-based
+  windows below. The per-notebook and per-source structural caps still apply.
+
+### `EylDcb` — Get Remaining Usage (compute windows)
+
+On 2026-09-02 Gemini Notebook replaced fixed daily caps for chat and Studio with
+a compute-based allowance. Consumption depends on prompt complexity and the
+features used, not on a count of requests, so the client cannot derive what is
+left by counting its own calls. This RPC reports it directly. Fires when the
+usage dialog is opened from the Settings menu.
+
+**Captured request params (2026-09-12):**
+```python
+# The standard RPC header is the only parameter:
+[[2, null, [1], [1, null, null, null, null, null, null, null, null, null, [1, 3]]]]
+```
+
+**Captured response (decoded, 2026-09-12):**
+```python
+[1,
+ [[null, null, null, null, 2, [1789697670, 16986000], 8.703406947222222, 91.29659305277778],
+  [null, null, null, null, 1, [1789200870, 16877000], null, 100]],
+ null,
+ [[1, true, 6, 3, 1, 11.177083333333334], ...]]   # 24 entries, appears to be recent activity
+```
+
+Each entry in `response[1]` describes one window:
+
+| Index | Meaning |
+|-------|---------|
+| 4 | Window type: `1` = short rolling window (~5h), `2` = weekly window |
+| 5 | Reset time as `[epoch_seconds, nanoseconds]` |
+| 6 | Percent of the allowance **used**; `null` when nothing has been consumed |
+| 7 | Percent of the allowance **remaining** |
+
+**Index 6 is "used" and index 7 is "remaining"**, confirmed two ways: the web
+dialog read "0% used" while the payload carried `100`, and a partly consumed
+account returned `8.703406947222222` beside `91.29659305277778`, which sum to
+exactly `100`.
+
+**⚠️ The two entries are NOT returned in a stable order.** Observed as `[2, 1]`
+in one call and `[1, 2]` in the next, for the same account. Always select a
+window by its type code at index 4; reading by position silently swaps the
+5-hour budget with the weekly one.
+
+**⚠️ An expired session is not an exhausted quota.** When the saved session has
+aged out, this RPC returns RPC error code 16 (`UNAUTHENTICATED`) and `ozz5Z`
+returns a well-formed but empty entitlement. Neither may be read as "out of
+quota" or as a free-tier account. Run `nlm auth refresh` and retry.
+
+**The `authuser` query parameter has no effect here.** Omitting it and passing
+`0`, `1` or `2` all returned byte-identical payloads for the same account.
+
+**Implementation:** `core/usage.py` (`UsageMixin`), `services/usage.py`,
+`nlm usage`, MCP tool `usage_get`.

--- a/docs/MCP_CLI_TEST_PLAN.md
+++ b/docs/MCP_CLI_TEST_PLAN.md
@@ -1039,6 +1039,31 @@ Get Gemini Notebook MCP server version and check for updates.
 
 ---
 
+## Test Group 13: Plan Usage
+
+### Test 13.1 - Get Remaining Usage
+**Tool:** `usage_get`
+**CLI (Noun):** `nlm usage` (add `--json` for raw output)
+
+**Prompt:**
+```
+How much of my Gemini Notebook usage allowance is left?
+```
+
+**Expected:**
+- `windows`: two entries, `rolling` first then `weekly`
+- each with `percent_used`, `percent_remaining` and `resets_at` (ISO 8601 UTC)
+- `tier`: subscription tier string, e.g. `NOTEBOOKLM_TIER_PRO_CONSUMER_USER`
+
+**Also verify:**
+- Run it twice. The reported order stays `rolling`, `weekly` even though the API
+  returns the two entries in an unstable order.
+- `percent_used` and `percent_remaining` sum to 100 for a partly consumed window.
+- With an expired session it reports an authentication error and hints at
+  `nlm auth refresh`. It must NOT report the allowance as exhausted.
+
+---
+
 ## Summary: 31 Consolidated Tools
 
 | Category | Tools | Count |

--- a/src/notebooklm_tools/cli/commands/usage.py
+++ b/src/notebooklm_tools/cli/commands/usage.py
@@ -1,0 +1,91 @@
+"""Show how much of the plan's usage allowance is left."""
+
+import json as json_lib
+from datetime import UTC, datetime
+
+import typer
+from rich.table import Table
+
+from notebooklm_tools.cli.utils import get_client, handle_error, make_console
+from notebooklm_tools.services import usage as usage_service
+
+console = make_console()
+app = typer.Typer(
+    name="usage",
+    help="Show remaining plan usage and reset times",
+    invoke_without_command=True,
+)
+
+_WINDOW_LABELS = {
+    "rolling": "Rolling window",
+    "weekly": "Weekly limit",
+}
+
+
+def _format_reset(iso_value: str | None) -> str:
+    """Render a reset time in the user's local timezone."""
+    if not iso_value:
+        return "unknown"
+    try:
+        parsed = datetime.fromisoformat(iso_value)
+    except ValueError:
+        return iso_value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone().strftime("%Y-%m-%d %H:%M %Z")
+
+
+def _format_percent(value: float | None) -> str:
+    """Render a percentage, distinguishing unknown from zero."""
+    if value is None:
+        return "unknown"
+    return f"{value:.1f}%"
+
+
+@app.callback(invoke_without_command=True)
+def usage(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON"),
+) -> None:
+    """
+    Show how much of your plan's usage allowance is left.
+
+    Gemini Notebook meters usage as compute against two windows at once: a short
+    rolling window and a weekly one. Both are shown with their reset times.
+
+    Examples:
+        nlm usage
+        nlm usage --json
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    try:
+        client = get_client()
+        result = usage_service.get_usage(client)
+    except Exception as e:
+        handle_error(e, json_output)
+        return
+
+    if json_output:
+        console.print(json_lib.dumps(result, indent=2))
+        return
+
+    table = Table(title="Gemini Notebook usage")
+    table.add_column("Window", style="cyan")
+    table.add_column("Used", justify="right")
+    table.add_column("Remaining", justify="right")
+    table.add_column("Resets")
+
+    for window in result["windows"]:
+        table.add_row(
+            _WINDOW_LABELS.get(window["window"], window["window"]),
+            _format_percent(window["percent_used"]),
+            _format_percent(window["percent_remaining"]),
+            _format_reset(window["resets_at"]),
+        )
+
+    console.print(table)
+
+    tier = result.get("tier")
+    console.print(f"Plan: [bold]{tier}[/bold]" if tier else "Plan: [dim]unknown[/dim]")

--- a/src/notebooklm_tools/cli/main.py
+++ b/src/notebooklm_tools/cli/main.py
@@ -40,6 +40,7 @@ from notebooklm_tools.cli.commands.studio import (
     video_app,
 )
 from notebooklm_tools.cli.commands.tag import app as tag_app
+from notebooklm_tools.cli.commands.usage import app as usage_app
 from notebooklm_tools.cli.commands.verbs import (
     add_app,
     configure_app,
@@ -879,6 +880,7 @@ app.add_typer(batch_app, name="batch", help="Batch operations across notebooks")
 app.add_typer(cross_app, name="cross", help="Cross-notebook queries")
 app.add_typer(pipeline_app, name="pipeline", help="Run multi-step pipelines")
 app.add_typer(tag_app, name="tag", help="Manage notebook tags")
+app.add_typer(usage_app, name="usage", help="Show remaining plan usage and reset times")
 
 # Generation commands as top-level
 app.add_typer(audio_app, name="audio", help="Create audio overviews")

--- a/src/notebooklm_tools/core/base.py
+++ b/src/notebooklm_tools/core/base.py
@@ -305,6 +305,14 @@ class BaseClient:
     # Export RPCs
     RPC_EXPORT_ARTIFACT = "Krh3pd"  # Export to Google Docs/Sheets
 
+    # Usage RPCs
+    RPC_GET_USAGE = "EylDcb"  # Remaining allowance and reset time per usage window
+    # Same endpoint as RPC_ADD_SOURCE_V2: Google dual-maps ozz5Z, returning the
+    # subscription tier for homepage params and adding a URL source for notebook
+    # params. Kept as its own constant so the two uses stay independently
+    # documented and independently patchable via NOTEBOOKLM_RPC_OVERRIDES.
+    RPC_GET_ENTITLEMENT = "ozz5Z"  # Subscription tier the account is entitled to
+
     # =========================================================================
     # API Constants (re-exported from constants module)
     # =========================================================================

--- a/src/notebooklm_tools/core/client.py
+++ b/src/notebooklm_tools/core/client.py
@@ -30,6 +30,7 @@ from .research import ResearchMixin
 from .sharing import SharingMixin
 from .sources import SourceMixin
 from .studio import StudioMixin
+from .usage import UsageMixin
 
 # Backward compatibility alias - code importing AuthenticationError from client.py
 # will get the ClientAuthenticationError from errors.py
@@ -53,6 +54,7 @@ class NotebookLMClient(
     NotesMixin,
     LabelsMixin,
     CollectionsMixin,
+    UsageMixin,
 ):
     """Client for NotebookLM MCP internal API.
 

--- a/src/notebooklm_tools/core/usage.py
+++ b/src/notebooklm_tools/core/usage.py
@@ -1,0 +1,105 @@
+"""UsageMixin - plan usage allowance and subscription tier.
+
+Gemini Notebook replaced fixed daily caps with a compute-based allowance in
+September 2026. Two windows apply at once: a short rolling window and a weekly
+window. The backend reports the remaining percentage and the reset time for
+both, so no client-side estimation of compute cost is needed.
+"""
+
+import logging
+
+from .base import BaseClient
+
+logger = logging.getLogger(__name__)
+
+# Window type codes returned at index 4 of each usage entry.
+USAGE_WINDOW_ROLLING = 1
+USAGE_WINDOW_WEEKLY = 2
+
+# Product ID the entitlement RPC is queried against, matching the value already
+# recorded in docs/API_REFERENCE.md. The backend accepts more than one value
+# here and returns the same tier for each (1469 was also observed working).
+_ENTITLEMENT_PRODUCT_ID = 627
+
+
+class UsageMixin(BaseClient):
+    """Mixin for reading plan usage windows and subscription tier."""
+
+    def _get_usage_header(self) -> list:
+        """Returns the standard header these RPCs expect as their only param."""
+        return [2, None, [1], [1, None, None, None, None, None, None, None, None, None, [1, 3]]]
+
+    def get_usage(self) -> list[dict]:
+        """Fetch the remaining allowance for every usage window.
+
+        Returns:
+            One dict per window, each with:
+                - window: ``USAGE_WINDOW_ROLLING`` or ``USAGE_WINDOW_WEEKLY``
+                - percent_used: float or None when nothing has been consumed
+                - percent_remaining: float or None when the backend omits it
+                - resets_at: reset time as epoch seconds (int), or None
+        """
+        result = self._call_rpc(self.RPC_GET_USAGE, [self._get_usage_header()])
+
+        if not isinstance(result, list) or len(result) < 2 or not isinstance(result[1], list):
+            logger.debug("Unexpected usage payload shape: %r", result)
+            return []
+
+        windows = []
+        for entry in result[1]:
+            # Entries are NOT returned in a stable order, so the window is
+            # identified by its type code rather than by position.
+            if not isinstance(entry, list) or len(entry) < 8:
+                continue
+
+            reset = entry[5]
+            resets_at = reset[0] if isinstance(reset, list) and reset else None
+
+            windows.append(
+                {
+                    "window": entry[4],
+                    "percent_used": entry[6],
+                    "percent_remaining": entry[7],
+                    "resets_at": resets_at,
+                }
+            )
+
+        return windows
+
+    def get_entitlement_tier(self) -> str | None:
+        """Fetch the subscription tier this account is entitled to.
+
+        Returns:
+            The tier string (for example ``NOTEBOOKLM_TIER_PRO_CONSUMER_USER``),
+            or None when the backend returns no entitlement for the account.
+        """
+        params = [
+            [
+                [
+                    [None, "1", _ENTITLEMENT_PRODUCT_ID],
+                    [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                    1,
+                ]
+            ]
+        ]
+        result = self._call_rpc(self.RPC_GET_ENTITLEMENT, params)
+        return _find_tier(result)
+
+
+def _find_tier(node: object, depth: int = 0) -> str | None:
+    """Return the first tier string found anywhere in a decoded payload.
+
+    The entitlement response nests the tier inside promotional and billing
+    structures whose shape varies with the account's plan and offers, so the
+    tier is located by its value rather than by a fixed index path.
+    """
+    if depth > 12:
+        return None
+    if isinstance(node, str):
+        return node if node.startswith("NOTEBOOKLM_TIER_") else None
+    if isinstance(node, list):
+        for item in node:
+            found = _find_tier(item, depth + 1)
+            if found:
+                return found
+    return None

--- a/src/notebooklm_tools/mcp/server.py
+++ b/src/notebooklm_tools/mcp/server.py
@@ -97,6 +97,7 @@ def _register_tools() -> None:
         sources,
         studio,
         studio_advanced,
+        usage,
     )
     from .tools._utils import register_all_tools
 

--- a/src/notebooklm_tools/mcp/tool_groups.py
+++ b/src/notebooklm_tools/mcp/tool_groups.py
@@ -1,6 +1,6 @@
 """Optional group-based gating of MCP tools.
 
-The server registers a large tool set (43 tools). Clients that only need a
+The server registers a large tool set (49 tools). Clients that only need a
 subset can hide the rest to save context, without editing code, by toggling
 named groups or individual tools through environment variables.
 
@@ -84,6 +84,9 @@ TOOL_GROUPS: dict[str, set[str]] = {
     },
     "server": {
         "server_info",
+    },
+    "usage": {
+        "usage_get",
     },
     "sharing": {
         "notebook_share_status",

--- a/src/notebooklm_tools/mcp/tools/__init__.py
+++ b/src/notebooklm_tools/mcp/tools/__init__.py
@@ -61,6 +61,7 @@ from .studio import (
     studio_revise,
     studio_status,
 )
+from .usage import usage_get
 
 __all__ = [
     # Downloads (1 consolidated + 1 bulk)
@@ -120,6 +121,7 @@ __all__ = [
     "label",
     # Server (1)
     "server_info",
+    "usage_get",
     # Batch (1 consolidated — action: query|add_source|create|delete|studio)
     "batch",
     # Cross-notebook (1)

--- a/src/notebooklm_tools/mcp/tools/usage.py
+++ b/src/notebooklm_tools/mcp/tools/usage.py
@@ -1,0 +1,23 @@
+"""Usage tools - plan allowance windows and subscription tier."""
+
+from ...services import ServiceError
+from ...services import usage as usage_service
+from ._utils import ResultDict, error_result, get_client, logged_tool
+
+
+@logged_tool()
+def usage_get() -> ResultDict:
+    """Show how much of the plan's usage allowance is left, and when it resets.
+
+    Gemini Notebook meters usage as compute against two windows at once: a short
+    rolling window and a weekly one. Both are reported, each with the percentage
+    used, the percentage remaining and the reset time in UTC.
+    """
+    try:
+        client = get_client()
+        result = usage_service.get_usage(client)
+        return {"status": "success", **result}
+    except ServiceError as e:
+        return error_result(e.user_message, hint=e.hint)
+    except Exception as e:
+        return error_result(str(e))

--- a/src/notebooklm_tools/services/usage.py
+++ b/src/notebooklm_tools/services/usage.py
@@ -1,0 +1,100 @@
+"""Usage service — plan allowance windows and subscription tier.
+
+Gemini Notebook meters usage as compute against two simultaneous windows: a
+short rolling window and a weekly one. The backend reports what is left in each
+and when it resets, so this service reports measured values and never estimates
+the cost of a prompt.
+"""
+
+from datetime import UTC, datetime
+
+from ..core.client import NotebookLMClient
+from ..core.usage import USAGE_WINDOW_ROLLING, USAGE_WINDOW_WEEKLY
+from .errors import ServiceError
+
+_WINDOW_NAMES = {
+    USAGE_WINDOW_ROLLING: "rolling",
+    USAGE_WINDOW_WEEKLY: "weekly",
+}
+
+# The backend returns the windows in an unstable order, so output is sorted to
+# keep it deterministic for anyone parsing it. Shortest window first, since that
+# is the one that blocks work soonest. Unknown windows sort last.
+_WINDOW_ORDER = ["rolling", "weekly"]
+
+
+def _to_iso(epoch_seconds: int | None) -> str | None:
+    """Convert epoch seconds to an ISO 8601 UTC string."""
+    if epoch_seconds is None:
+        return None
+    try:
+        return datetime.fromtimestamp(epoch_seconds, UTC).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _shape_window(raw: dict) -> dict:
+    """Normalize one raw window entry into the reported shape.
+
+    ``percent_used`` is absent rather than zero when nothing has been consumed,
+    so it is normalized to 0.0 only when the remaining percentage confirms a
+    full allowance. Anything else is reported as None, which callers must read
+    as unknown rather than as zero.
+    """
+    remaining = raw.get("percent_remaining")
+    used = raw.get("percent_used")
+
+    if used is None and remaining == 100:
+        used = 0.0
+
+    return {
+        "window": _WINDOW_NAMES.get(raw.get("window"), "unknown"),
+        "percent_used": used,
+        "percent_remaining": remaining,
+        "resets_at": _to_iso(raw.get("resets_at")),
+    }
+
+
+def get_usage(client: NotebookLMClient) -> dict:
+    """Report the remaining allowance for each usage window, plus the plan tier.
+
+    The tier is best-effort: a failure to read it must not deny the caller the
+    usage figures, which are the part that governs whether work can proceed.
+
+    Returns a dict with:
+        - windows: list of window dicts, each with window, percent_used,
+          percent_remaining and resets_at (ISO 8601 UTC)
+        - tier: the subscription tier string, or None when unavailable
+    """
+    try:
+        raw_windows = client.get_usage()
+    except Exception as e:
+        # An expired session surfaces here as an authentication error. Callers
+        # must be able to tell that apart from an exhausted allowance, so the
+        # failure is reported as-is rather than as a quota result.
+        raise ServiceError(
+            f"Failed to read usage: {e}",
+            user_message=f"Could not read plan usage — {e}",
+            hint="If this is an authentication error, run 'nlm auth refresh' or 'nlm login'.",
+        ) from e
+
+    if not raw_windows:
+        raise ServiceError(
+            "Usage response contained no windows",
+            user_message="Gemini Notebook returned no usage information.",
+            hint="The response shape may have changed. Re-run with --debug to inspect it.",
+        )
+
+    try:
+        tier = client.get_entitlement_tier()
+    except Exception:
+        tier = None
+
+    windows = [_shape_window(w) for w in raw_windows]
+    windows.sort(
+        key=lambda w: (
+            _WINDOW_ORDER.index(w["window"]) if w["window"] in _WINDOW_ORDER else len(_WINDOW_ORDER)
+        )
+    )
+
+    return {"windows": windows, "tier": tier}

--- a/tests/services/test_usage.py
+++ b/tests/services/test_usage.py
@@ -1,0 +1,133 @@
+"""Tests for the usage service.
+
+Fixtures are trimmed copies of real `EylDcb` responses captured from the live
+API, including one where the two windows arrive in the opposite order.
+"""
+
+import pytest
+
+from notebooklm_tools.core.usage import UsageMixin, _find_tier
+from notebooklm_tools.services.errors import ServiceError
+from notebooklm_tools.services.usage import get_usage
+
+# Weekly window partly consumed, rolling window untouched. Rolling arrives first.
+USAGE_ROLLING_FIRST = [
+    1,
+    [
+        [None, None, None, None, 1, [1789200870, 16877000], None, 100],
+        [None, None, None, None, 2, [1789697670, 16986000], 8.703406947222222, 91.29659305277778],
+    ],
+    None,
+    [[1, True, 6, 3, 1, 11.177083333333334]],
+]
+
+# The same account, same call, with the windows in the opposite order. The API
+# does not guarantee ordering, so the service must key on the window type code.
+USAGE_WEEKLY_FIRST = [
+    1,
+    [
+        [None, None, None, None, 2, [1789697670, 16986000], 8.703406947222222, 91.29659305277778],
+        [None, None, None, None, 1, [1789200870, 16877000], None, 100],
+    ],
+    None,
+    [],
+]
+
+ENTITLEMENT = [[[[None, "1", 1469], None, 1386, "NOTEBOOKLM_TIER_PRO_CONSUMER_USER", False]]]
+
+
+class FakeClient(UsageMixin):
+    """Exercises the real mixin parsing against canned RPC responses."""
+
+    def __init__(self, usage_payload, entitlement_payload=ENTITLEMENT, usage_error=None):
+        self._usage_payload = usage_payload
+        self._entitlement_payload = entitlement_payload
+        self._usage_error = usage_error
+
+    def _call_rpc(self, rpc_id, params, *args, **kwargs):
+        if rpc_id == self.RPC_GET_USAGE:
+            if self._usage_error:
+                raise self._usage_error
+            return self._usage_payload
+        if rpc_id == self.RPC_GET_ENTITLEMENT:
+            if isinstance(self._entitlement_payload, Exception):
+                raise self._entitlement_payload
+            return self._entitlement_payload
+        raise AssertionError(f"unexpected rpc {rpc_id}")
+
+
+def _by_window(result):
+    return {w["window"]: w for w in result["windows"]}
+
+
+def test_reports_both_windows_with_percentages_and_reset_times():
+    result = get_usage(FakeClient(USAGE_ROLLING_FIRST))
+    windows = _by_window(result)
+
+    assert set(windows) == {"rolling", "weekly"}
+    assert windows["weekly"]["percent_used"] == pytest.approx(8.7034069, rel=1e-6)
+    assert windows["weekly"]["percent_remaining"] == pytest.approx(91.2965930, rel=1e-6)
+    assert windows["weekly"]["resets_at"] == "2026-09-18T02:14:30+00:00"
+    assert result["tier"] == "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"
+
+
+def test_window_identity_survives_reordering():
+    """The API reorders these entries, so position must never identify a window."""
+    first = _by_window(get_usage(FakeClient(USAGE_ROLLING_FIRST)))
+    second = _by_window(get_usage(FakeClient(USAGE_WEEKLY_FIRST)))
+
+    assert first["weekly"] == second["weekly"]
+    assert first["rolling"] == second["rolling"]
+    # The bug this guards against: reading by position swaps the two budgets.
+    assert first["weekly"]["percent_remaining"] != first["rolling"]["percent_remaining"]
+
+
+def test_absent_used_percentage_is_zero_only_when_allowance_is_full():
+    windows = _by_window(get_usage(FakeClient(USAGE_ROLLING_FIRST)))
+    assert windows["rolling"]["percent_used"] == 0.0
+    assert windows["rolling"]["percent_remaining"] == 100
+
+
+def test_absent_used_percentage_stays_unknown_when_allowance_is_partial():
+    payload = [1, [[None, None, None, None, 1, [1789200870, 0], None, 55.0]], None, []]
+    windows = _by_window(get_usage(FakeClient(payload)))
+    assert windows["rolling"]["percent_used"] is None
+    assert windows["rolling"]["percent_remaining"] == 55.0
+
+
+def test_authentication_failure_is_raised_not_reported_as_quota():
+    """An expired session must never look like an exhausted allowance."""
+    client = FakeClient(None, usage_error=RuntimeError("Authentication expired"))
+    with pytest.raises(ServiceError) as excinfo:
+        get_usage(client)
+    assert "auth refresh" in (excinfo.value.hint or "")
+
+
+def test_empty_window_list_raises():
+    with pytest.raises(ServiceError):
+        get_usage(FakeClient([1, [], None, []]))
+
+
+def test_malformed_payload_raises():
+    with pytest.raises(ServiceError):
+        get_usage(FakeClient(["unexpected"]))
+
+
+def test_tier_failure_does_not_deny_usage_figures():
+    client = FakeClient(USAGE_ROLLING_FIRST, entitlement_payload=RuntimeError("boom"))
+    result = get_usage(client)
+    assert result["tier"] is None
+    assert len(result["windows"]) == 2
+
+
+def test_find_tier_ignores_unrelated_strings():
+    assert _find_tier([["Manage subscription", ["CAI="]]]) is None
+    assert _find_tier([[["NOTEBOOKLM_TIER_FREE_USER"]]]) == "NOTEBOOKLM_TIER_FREE_USER"
+
+
+def test_output_order_is_stable_regardless_of_api_order():
+    """The API reorders its entries; the reported order must not follow it."""
+    rolling_first = [w["window"] for w in get_usage(FakeClient(USAGE_ROLLING_FIRST))["windows"]]
+    weekly_first = [w["window"] for w in get_usage(FakeClient(USAGE_WEEKLY_FIRST))["windows"]]
+
+    assert rolling_first == weekly_first == ["rolling", "weekly"]


### PR DESCRIPTION
## What

Adds `nlm usage` and the MCP tool `usage_get`, which report how much of the account's plan allowance is left and when it resets.

```
                             Gemini Notebook usage
┏━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Window         ┃ Used ┃ Remaining ┃ Resets                                   ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Rolling window │ 0.0% │    100.0% │ 2026-09-12 13:44 Sri Lanka Standard Time │
│ Weekly limit   │ 8.7% │     91.3% │ 2026-09-18 07:44 Sri Lanka Standard Time │
└────────────────┴──────┴───────────┴──────────────────────────────────────────┘
Plan: NOTEBOOKLM_TIER_PRO_CONSUMER_USER
```

## Why

On 2026-09-02 Gemini Notebook replaced fixed daily caps for chat and Studio with a compute-based allowance metered against two windows at once: a short rolling window and a weekly cap. Consumption depends on prompt complexity and the features used rather than on a count of requests, so a client cannot work out what is left by counting its own calls.

The existing handling is reactive only: `RESOURCE_EXHAUSTED` triggers exponential backoff capped at 16 seconds, which cannot help when the real wait is hours. This PR does not change that backoff. It adds the missing ability to see the budget before starting work, which is the prerequisite for anything smarter later.

## How

`EylDcb` returns the percentage used and remaining plus a reset timestamp for each window. The existing `ozz5Z` endpoint returns the subscription tier that sizes the allowance; it keeps its own purpose-named constant beside `RPC_ADD_SOURCE_V2` since Google dual-maps that ID, so the two uses stay independently documented and independently patchable via `NOTEBOOKLM_RPC_OVERRIDES`.

Layering follows the existing rules: `core/usage.py` holds a `UsageMixin` with no business logic, `services/usage.py` does the parsing and raises `ServiceError`, and the CLI and MCP wrappers are thin and never import `core/` directly.

Two behaviours are load-bearing and both are covered by tests:

**The two window entries are not returned in a stable order.** The same account returned them as `[2, 1]` on one call and `[1, 2]` on the very next. Windows are therefore keyed by the type code at index 4, never by position, and the reported order is sorted so consumers get something deterministic. Reading by position silently swaps the 5-hour budget with the weekly one, which is exactly the kind of bug that looks fine until it matters.

**An expired session is not an exhausted quota.** A stale session makes the usage RPC return error code 16 and the tier RPC return a well-formed but empty entitlement. Neither is reported as out of quota or as a free-tier account. The error surfaces with a hint pointing at `nlm auth refresh`. Reading the tier is best-effort and its failure never denies the caller the usage figures.

I also found that the `authuser` query parameter has no effect on this RPC: omitting it and passing `0`, `1` or `2` returned byte-identical payloads for the same account. No URL change was needed.

## Verification

Tested against the live Gemini Notebook API with a real Pro account, not just mocks.

- **CLI:** `nlm usage` and `nlm usage --json`, output above.
- **MCP:** driven over stdio against the real server. `usage_get` registers (49 tools total) and returns the same figures as the CLI.
- **Field mapping:** index 6 is percent used and index 7 is percent remaining, confirmed two ways. The web dialog read "0% used" while the payload carried `100`, and a partly consumed account returned `8.703406947222222` beside `91.29659305277778`, which sum to exactly `100`.
- **Tests:** 10 new unit tests in `tests/services/test_usage.py` using fixtures recorded from real responses, including one with the windows reversed. Each was mutation-checked: breaking the type-code keying, the "used is null" handling, or the auth-error hint each fails the test written to catch it.
- **Suite:** `uv run pytest` shows no new failures. The 4 remaining failures are pre-existing on `main` in this environment (Windows/macOS path assumptions), verified by stashing this branch and re-running them.
- **Lint:** `uv run ruff check .` and `uv run ruff format --check .` both clean.

## Notes

- `usage_get` is in its own `usage` tool group rather than the `server` group, since account quota is not MCP server runtime info, and `server` is asserted elsewhere to hold exactly one tool.
- Read-only, so no `confirm` parameter.
- No new dependencies. No version bump.
- Also corrects the README and CLAUDE.md, which still described a fixed "~50 queries/day" free-tier cap, and `docs/API_REFERENCE.md`, which stated that no endpoint existed to query current usage.
